### PR TITLE
REMOTE_DIR/LOCAL_DIR and fallback ssh-copy-id mechanism fixes.

### DIFF
--- a/bin/lipsync
+++ b/bin/lipsync
@@ -45,7 +45,7 @@ fi
 # run the rsync command to check server for updated files
 ###############
 #/usr/bin/rsync $@ || err=$?
-rsync -rav --stats --log-file=/home/$USER_NAME/.lipsyncd/lipsyncd.log -e "ssh -l $USER_NAME -p $SSH_PORT" --delete $REMOTE_HOST:$LOCAL_DIR $REMOTE_DIR
+rsync -rav --stats --log-file=/home/$USER_NAME/.lipsyncd/lipsyncd.log -e "ssh -l $USER_NAME -p $SSH_PORT" --delete $REMOTE_HOST:$REMOTE_DIR $LOCAL_DIR
 
 ###############
 # this writes source -> destination details to lipsyncd.log

--- a/install.sh
+++ b/install.sh
@@ -104,7 +104,7 @@ ssh.keygen(){
 			exit 1 
 		fi
 	else
-  		su ${username} -c "cat /home/${username}/.ssh/id_rsa.pub | ssh $remote_server -p ${port} 'cat - > /home/${username}/.ssh/id_dsa.pub'" >> /dev/null
+  		su ${username} -c "cat /home/${username}/.ssh/id_dsa.pub | ssh $remote_server -p ${port} 'cat - >> /home/${username}/.ssh/authorized_keys'" >> /dev/null
   		if [ $? -eq 0 ]; then
   			X=0	#echo "done"
   		else

--- a/install.sh
+++ b/install.sh
@@ -195,7 +195,7 @@ deploy(){
 initial_sync(){
 	echo -n "* Doing inital sync with server..."
 	. /etc/lipsyncd
-	su $USER_NAME -c 'rsync -rav --stats --log-file=/home/'$USER_NAME'/.lipsyncd/lipsyncd.log -e "ssh -l '$USER_NAME' -p '$SSH_PORT'" '$REMOTE_HOST':'$LOCAL_DIR' '$REMOTE_DIR''
+	su $USER_NAME -c 'rsync -rav --stats --log-file=/home/'$USER_NAME'/.lipsyncd/lipsyncd.log -e "ssh -l '$USER_NAME' -p '$SSH_PORT'" '$REMOTE_HOST':'$REMOTE_DIR' '$LOCAL_DIR''
 	echo "Initial sync `date` Completed" > /home/$username/.lipsyncd/lipsyncd.log
 }
 


### PR DESCRIPTION
I ran into a couple issues while experimenting with lipsync. The first patch addresses some mixup with REMOTE_DIR and LOCAL_DIR which manifest as an rsync file not found failure when the client and server use different sync paths. The second fixes a faulty ssh key copy mechanism if ssh-copy-id doesn't exist on the client.
