### PR TITLE
here follow a simple patch to install.sh wich was missing an chmod +x to init.d job

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -149,8 +149,7 @@ deploy(){
 	echo "done"
 
 	echo -n "	> /etc/init.d/lipsyncd..."
-	cp etc/init.d/lipsyncd /etc/init.d
-	chmod +x /etc/init.d/lipsyncd
+	install -m 755 etc/init.d/lipsyncd /etc/init.d/
 	echo "done"
 
 	echo -n "	> Installing cron for user $username..."

--- a/install.sh
+++ b/install.sh
@@ -150,6 +150,7 @@ deploy(){
 
 	echo -n "	> /etc/init.d/lipsyncd..."
 	cp etc/init.d/lipsyncd /etc/init.d
+	chmod +x /etc/init.d/lipsyncd
 	echo "done"
 
 	echo -n "	> Installing cron for user $username..."


### PR DESCRIPTION
fix permission issue related to the init.d job (execution right was missing)
